### PR TITLE
Added Support for Emergency Priority

### DIFF
--- a/Pushover.php
+++ b/Pushover.php
@@ -329,6 +329,9 @@ class Pushover
     public function getUrlTitle () {
         return $this->_url_title;
     }
+	
+	
+	
 
 	/**
 	 * Set debug mode

--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@
 > Leave this empty if you want to send to all user's devices. This can be user specific!
 
 * setPriority
-> Default = 0, if 1 the user's quiet hours will be ignored + messages displayed in red.
+> Default = 0, if 1 the user's quiet hours will be ignored + messages displayed in red. If 2, the same behaviour as 1 applies; but the message will repeat until the user acknowledges it.
+
+* setExpire
+> The expire parameter is only used when the Priority is set to 2 (or emergency-priority), and specifies how many seconds your notification will continue to be retried for. (Max Value = 86400)
+
+* setRetry
+> The Retry parameter is only used when the Priority is set to 2 (or emergency-priority), and specifies how often (in seconds) the Pushover servers will send the same notification to the user. (Min Value = 30)
 
 * setTimestamp
 > Messages are stored on the Pushover servers with a timestamp of when they were initially received through the API. This timestamp is sent to and shown on client devices, and messages are listed in order of these timestamps. In most cases, this default timestamp is acceptable. This is not for scheduling!

--- a/test.php
+++ b/test.php
@@ -16,7 +16,9 @@ $push->setUrl('http://chris.schalenborgh.be/blog/');
 $push->setUrlTitle('cool php blog');
 
 $push->setDevice('iPhone');
-$push->setPriority(1);
+$push->setPriority(2);
+$push->setRetry(60); //Used with Priority = 2; Pushover will resend the notification every 60 seconds until the user accepts.
+$push->setExpire(3600); //Used with Priority = 2; Pushover will resend the notification every 60 seconds for 3600 seconds. After that point, it stops sending notifications.
 $push->setTimestamp(time());
 $push->setDebug(true);
 


### PR DESCRIPTION
Hi!

Pushover has support for Emergency Priority notifications (https://pushover.net/api#priority) so I added support for php-pushover to send out Emergency Priority Notifications (with the 'expire' + 'retry' parameters). I've updated the readme documentation with descriptions on the expire + retry parameters/functions, updated the test.php showing this new functionality and also added comments in Pushover.php explaining what these new parameters do.

After doing some testing, I discovered that even if expire/retry variables are set and the priority is <2, the notification will still send (Pushover seems to disregard the expire + retry variables if the priority is <2). Hence why there aren't 2 seperate curlopt_postfield lines.
