### PR TITLE
Add receipt functionality

### DIFF
--- a/Pushover.php
+++ b/Pushover.php
@@ -129,6 +129,13 @@ class Pushover
     private $_sound;
 
     /**
+     * The receipt parameter. The receipt of the last send message
+     *
+     * @var int
+     */
+    private $_receipt;
+
+    /**
      * Default constructor
      */
     public function __construct () {
@@ -419,6 +426,26 @@ class Pushover
     }
 
     /**
+     * Set receipt mode
+     *
+     * @param string $receipt Set receipt string
+     *
+     * @return void
+     */
+    public function setReceipt ($receipt) {
+        $this->_receipt = (string)$receipt;
+    }
+
+    /**
+     * Get last receipt
+     *
+     * @return string
+     */
+    public function getReceipt () {
+        return $this->_receipt;
+    }
+
+    /**
      * Set debug mode
      *
      * @param bool $debug Enable this to receive detailed input and output info.
@@ -511,6 +538,9 @@ class Pushover
             ));
             $response = curl_exec($c);
             $xml = simplexml_load_string($response);
+
+            # Store notification-receipt
+            $this->setReceipt( $xml->receipt );
 
             if($this->getDebug()) {
                 return array('output' => $xml, 'input' => $this);

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@
 * setTimestamp
 > Messages are stored on the Pushover servers with a timestamp of when they were initially received through the API. This timestamp is sent to and shown on client devices, and messages are listed in order of these timestamps. In most cases, this default timestamp is acceptable. This is not for scheduling!
 
+* getReceipt
+> Gets the pushover receipt identifier to be used in later calls to the receipt API.
+
 * setDebug
 > Enable this to receive detailed input and output info.
 

--- a/test.php
+++ b/test.php
@@ -26,7 +26,10 @@ $push->setSound('bike');
 
 $go = $push->send();
 
+$receipt = $push->getReceipt();
+
 echo '<pre>';
 print_r($go);
+print "Receipt: $receipt\n";
 echo '</pre>';
 ?>


### PR DESCRIPTION
Added support for getting the pushover receipt identifier after sending a notification.
This identifier can be used in the callback or receipt api.